### PR TITLE
bug fix for escaped querystring values comming from github

### DIFF
--- a/lib/gith.js
+++ b/lib/gith.js
@@ -10,6 +10,7 @@ var http = require("http");
 var EventEmitter2 = require( "eventemitter2" ).EventEmitter2;
 var util = require("util");
 var _ = require("lodash");
+var querystring = require("querystring");
 
 var filterSettings = function( settings, payload ) {
 
@@ -231,7 +232,7 @@ var listen = function( eventaur, port ) {
 
     req.on( "end", function() {
       if ( /^payload=/.test( data ) ) {
-        var payload = JSON.parse( data.slice(8) );
+        var payload = JSON.parse( querystring.unescape(data.slice(8)) );
         eventaur.emit( "payload", payload );
       }
       res.end();


### PR DESCRIPTION
This is for the issue I just posted. I thought I'd be able to match the issue to the pull request, but I'm not sure how.
