### PR TITLE
Fix filter all

### DIFF
--- a/lib/gith.js
+++ b/lib/gith.js
@@ -82,7 +82,7 @@ var filterSettings = function( settings, payload ) {
       }
 
       // assign the final result of this 'thing' to checksPassed
-      checksPassed = passed;
+      checksPassed = passed && checksPassed;
     }
   });
 

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "node": ">0.6.12"
   },
   "scripts": {
-    "test": "grunt test"
+    "test": "./node_modules/.bin/grunt test"
   },
   "dependencies": {
     "eventemitter2" : ">= 0.4.9" ,

--- a/test/gith_test.js
+++ b/test/gith_test.js
@@ -200,6 +200,13 @@ exports['gith filtering'] = {
       test.ok( false, 'repo should have matched, but not branch, so.....' );
     });
 
+    var test6 = gith({
+      repo: 'wrong/repo',
+      branch: 'merge-test'
+    }).on( 'all', function( payload ) {
+      test.ok( false, 'branch should have matched, but not repo, so.....' );
+    });
+
     // this needs to be improved
     setTimeout( function(){
       test.done();


### PR DESCRIPTION
I figured it would be nice to fix #9. Added a test case to reproduce @rafifyalda's issue, then made a small (one-line) fix.

(Also, changed the `npm test` command to use the grunt that's installed, for those who don't put `./node_modules/.bin` in their `PATH`. If you object to this I can easily re-submit a patch without it.)
