### PR TITLE
Crash when used as `pull_request` web hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ You can broadcast a payload to the gith server manually.
 
 When you use Github UI to declare a web hook, it's only attached to the `push` event.
 
-Whenever you want to attach you hook to other events, you will have to use [the API](http://developer.github.com/v3/repos/hooks/). In this case, `gith` may not be able to fully interpret the original payload, and you should simply rely on `payload.original`.
+Whenever you want to attach you hook to other events, you will have to use [the API](http://developer.github.com/v3/repos/hooks/). In this case, `gith` may not be able to fully interpret the original payload, and you **should consider the *simplified payload* as unreliable**. In those cases, just use `payload.original`.
 
 
 ## License

--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ Install the module with: `npm install gith`
 
 ### Require
 
-In your node application, require gith and create a gith server. You can specify a port now, or 
-you can use the `.listen( portNumber )` method later. 
+In your node application, require gith and create a gith server. You can specify a port now, or
+you can use the `.listen( portNumber )` method later.
 
 ```javascript
 // create a gith server on port 9001
@@ -32,12 +32,12 @@ gith({
 
 ### Hook
 
-Be sure github.com is sending payload data to your server. From your repository root 
+Be sure github.com is sending payload data to your server. From your repository root
 go to `Admin > Service Hooks > WebHook URLs` and add your server url, e.g., `http://mycoolserver.com:9001`.
 
 ## Filtering
 
-The object passed into `gith()` can utilize four parameters (`repo`, `branch`, `file` and `tag`). 
+The object passed into `gith()` can utilize four parameters (`repo`, `branch`, `file` and `tag`).
 All of these can either be an exact match string, a regular expression or a function.
 
 For example:
@@ -71,7 +71,7 @@ Events available are:
 
 ## Payload
 
-The github payload is very detailed, but can be a bit excessive. 
+The github payload is very detailed, but can be a bit excessive.
 
 This is the payload that gith gives you:
 
@@ -102,6 +102,8 @@ This is the payload that gith gives you:
 }
 ```
 
+Note that this payload will only be fully available in case of standard `push` hooks (see below for more information).
+
 ## `gith()`
 
 The gith function returns a new Gith object that has all of the [EventEmitter2](https://github.com/hij1nx/EventEmitter2)
@@ -114,11 +116,11 @@ On the gith server, there are three additional methods available:
 
 #### `gith.close()`
 
-This closes the gith server 
+This closes the gith server
 
 #### `gith.listen( port )`
 
-If you didn't pass in a port to `.create()` when you required gith, this 
+If you didn't pass in a port to `.create()` when you required gith, this
 will start the server on the specified port
 
 #### `gith.payload( github-style-payload )`
@@ -126,6 +128,14 @@ will start the server on the specified port
 You can broadcast a payload to the gith server manually.
 
 
+## Using `gith` for other types of hooks
+
+When you use Github UI to declare a web hook, it's only attached to the `push` event.
+
+Whenever you want to attach you hook to other events, you will have to use [the API](http://developer.github.com/v3/repos/hooks/). In this case, `gith` may not be able to fully interpret the original payload, and you should simply rely on `payload.original`.
+
+
 ## License
+
 Copyright (c) 2012 Dan Heberden
 Licensed under the MIT license.

--- a/lib/gith.js
+++ b/lib/gith.js
@@ -151,6 +151,8 @@ util.inherits( Gith, EventEmitter2 );
 
 // expose the simpliyPayload method on gith()
 Gith.prototype.simplifyPayload = function( payload ) {
+  payload = payload || {};
+
   var branch = '';
   var tag = '';
 

--- a/lib/gith.js
+++ b/lib/gith.js
@@ -177,19 +177,19 @@ Gith.prototype.simplifyPayload = function( payload ) {
     },
     tag: tag,
     branch: branch,
-    repo: payload.repository.owner.name + '/' + payload.repository.name,
+    repo: payload.repository ? (payload.repository.owner.name + '/' + payload.repository.name) : null,
     sha: payload.after,
-    time: payload.repository.pushed_at,
+    time: payload.repository ? payload.repository.pushed_at : null,
     urls: {
       head: payload.head_commit ? payload.head_commit.url : '',
       branch: '',
       tag: '',
-      repo: payload.repository.url,
+      repo: payload.repository ? payload.repository.url : null,
       compare: payload.compare
     },
     reset: !payload.created && payload.forced,
-    pusher: payload.pusher.name,
-    owner: payload.repository.owner.name
+    pusher: payload.pusher ? payload.pusher.name : null,
+    owner: (payload.repository && payload.repository.owner) ? payload.repository.owner.name : null
   };
 
   if ( branch ) {
@@ -200,7 +200,7 @@ Gith.prototype.simplifyPayload = function( payload ) {
   }
 
   // populate files for every commit
-  payload.commits.forEach( function( commit ) {
+  (payload.commits || []).forEach( function( commit ) {
     // github label and simpler label ( make 'removed' deleted to be consistant )
     _.each( { added: 'added', modified: 'modified', removed: 'deleted' }, function( s, g ) {
       simpler.files[ s ] = simpler.files[ s ].concat( commit[ g ] );

--- a/test/gith_test.js
+++ b/test/gith_test.js
@@ -98,7 +98,7 @@ exports['gith server'] = {
   'gith creates a server and listens to unescaped payloads on that port': function( test ) {
     test.expect(1);
     var gith = githFactory.create( 9001 );
-    
+
     var payloadObject = require('./payloads/add-file-and-dir.json');
     var failSafe = false;
     gith().on( 'all', function( payload ) {
@@ -128,7 +128,7 @@ exports['gith server'] = {
   'gith creates a server and listens to escaped payloads on that port': function( test ) {
     test.expect(1);
     var gith = githFactory.create( 9001 );
-    
+
     var payloadObject = require('./payloads/add-file-and-dir.json');
     var failSafe = false;
     gith().on( 'all', function( payload ) {
@@ -157,7 +157,7 @@ exports['gith server'] = {
   }
 };
 
-exports['gith filtering'] = { 
+exports['gith filtering'] = {
   setUp: function( done ) {
     done();
   },
@@ -165,7 +165,7 @@ exports['gith filtering'] = {
     test.expect(3);
     var json = require( './payloads/create-branch-with-files.json' );
     var gith = githFactory.create();
-    
+
     var test1 = gith({
       repo: 'danheberden/payloads'
     }).on( 'all', function( payload ) {
@@ -218,7 +218,7 @@ exports['gith filtering'] = {
     test.expect(3);
     var json = require( './payloads/tag-v1.0.0.json' );
     var gith = githFactory.create();
-    
+
     var test1 = gith({
       repo: /payloads/
     }).on( 'all', function( payload ) {
@@ -248,7 +248,7 @@ exports['gith filtering'] = {
   }
 };
 
- 
+
 exports['gith events'] = {
   setUp: function( done ) {
     done();
@@ -272,7 +272,7 @@ exports['gith events'] = {
     var gith = githFactory.create();
     var g = gith();
     g.on( 'file:delete', function( payload ) {
-      test.deepEqual( [ 'another2.txt' ], payload.files.deleted, 
+      test.deepEqual( [ 'another2.txt' ], payload.files.deleted,
                       'delete branch event should have deleted branch' );
       test.done();
     });
@@ -335,4 +335,24 @@ exports['gith events'] = {
     gith.payload( json );
   }
 
+};
+
+
+exports['other hook types'] = {
+  setUp: function( done ) {
+    done();
+  },
+  'pull-request.json': function( test ) {
+    test.expect(1);
+    var json = require( './payloads/pull-request.json' );
+    var gith = githFactory.create();
+    var g = gith();
+
+    g.on( 'all', function( payload ) {
+      // No particular expectation except it must not crash and present original payload
+      test.equal(payload.original, json);
+      test.done();
+    });
+    gith.payload( json );
+  }
 };

--- a/test/payloads/pull-request.json
+++ b/test/payloads/pull-request.json
@@ -1,0 +1,191 @@
+{
+  "number": 4,
+  "repository": {
+    "events_url": "https://api.github.com/repos/naholyr/gith/events",
+    "name": "gith",
+    "assignees_url": "https://api.github.com/repos/naholyr/gith/assignees{/user}",
+    "issue_comment_url": "https://api.github.com/repos/naholyr/gith/issues/comments/{number}",
+    "git_tags_url": "https://api.github.com/repos/naholyr/gith/git/tags{/sha}",
+    "open_issues_count": 4,
+    "size": 120,
+    "created_at": "2012-12-07T15:14:53Z",
+    "issues_url": "https://api.github.com/repos/naholyr/gith/issues{/number}",
+    "has_wiki": true,
+    "forks_count": 1,
+    "subscription_url": "https://api.github.com/repos/naholyr/gith/subscription",
+    "tags_url": "https://api.github.com/repos/naholyr/gith/tags{/tag}",
+    "branches_url": "https://api.github.com/repos/naholyr/gith/branches{/branch}",
+    "merges_url": "https://api.github.com/repos/naholyr/gith/merges",
+    "clone_url": "https://github.com/naholyr/gith.git",
+    "hooks_url": "https://api.github.com/repos/naholyr/gith/hooks",
+    "git_commits_url": "https://api.github.com/repos/naholyr/gith/git/commits{/sha}",
+    "private": false,
+    "forks_url": "https://api.github.com/repos/naholyr/gith/forks",
+    "updated_at": "2012-12-07T15:32:18Z",
+    "contents_url": "https://api.github.com/repos/naholyr/gith/contents/{+path}",
+    "watchers": 0,
+    "languages_url": "https://api.github.com/repos/naholyr/gith/languages",
+    "ssh_url": "git@github.com:naholyr/gith.git",
+    "fork": true,
+    "keys_url": "https://api.github.com/repos/naholyr/gith/keys{/key_id}",
+    "url": "https://api.github.com/repos/naholyr/gith",
+    "issue_events_url": "https://api.github.com/repos/naholyr/gith/issues/events{/number}",
+    "labels_url": "https://api.github.com/repos/naholyr/gith/labels{/name}",
+    "git_url": "git://github.com/naholyr/gith.git",
+    "notifications_url": "https://api.github.com/repos/naholyr/gith/notifications{?since,all,participating}",
+    "language": "JavaScript",
+    "id": 7055082,
+    "svn_url": "https://github.com/naholyr/gith",
+    "commits_url": "https://api.github.com/repos/naholyr/gith/commits{/sha}",
+    "downloads_url": "https://api.github.com/repos/naholyr/gith/downloads",
+    "pushed_at": "2012-12-07T15:30:45Z",
+    "comments_url": "https://api.github.com/repos/naholyr/gith/comments{/number}",
+    "open_issues": 4,
+    "has_downloads": true,
+    "mirror_url": null,
+    "archive_url": "https://api.github.com/repos/naholyr/gith/{archive_format}{/ref}",
+    "collaborators_url": "https://api.github.com/repos/naholyr/gith/collaborators{/collaborator}",
+    "homepage": null,
+    "statuses_url": "https://api.github.com/repos/naholyr/gith/statuses/{sha}",
+    "has_issues": false,
+    "trees_url": "https://api.github.com/repos/naholyr/gith/git/trees{/sha}",
+    "full_name": "naholyr/gith",
+    "git_refs_url": "https://api.github.com/repos/naholyr/gith/git/refs{/sha}",
+    "description": "simple node server that responds to github post-receive events with meaningful data",
+    "teams_url": "https://api.github.com/repos/naholyr/gith/teams",
+    "forks": 1,
+    "stargazers_url": "https://api.github.com/repos/naholyr/gith/stargazers",
+    "subscribers_url": "https://api.github.com/repos/naholyr/gith/subscribers",
+    "watchers_count": 0,
+    "html_url": "https://github.com/naholyr/gith",
+    "blobs_url": "https://api.github.com/repos/naholyr/gith/git/blobs{/sha}",
+    "compare_url": "https://api.github.com/repos/naholyr/gith/compare/{base}...{head}",
+    "milestones_url": "https://api.github.com/repos/naholyr/gith/milestones{/number}",
+    "owner": {
+      "avatar_url": "https://secure.gravatar.com/avatar/396445b6e14727dcb6b3d6a66d52b567?d=https://a248.e.akamai.net/assets.github.com%2Fimages%2Fgravatars%2Fgravatar-user-420.png",
+      "events_url": "https://api.github.com/users/naholyr/events{/privacy}",
+      "gists_url": "https://api.github.com/users/naholyr/gists{/gist_id}",
+      "gravatar_id": "396445b6e14727dcb6b3d6a66d52b567",
+      "received_events_url": "https://api.github.com/users/naholyr/received_events",
+      "starred_url": "https://api.github.com/users/naholyr/starred{/owner}{/repo}",
+      "url": "https://api.github.com/users/naholyr",
+      "id": 214067,
+      "following_url": "https://api.github.com/users/naholyr/following",
+      "subscriptions_url": "https://api.github.com/users/naholyr/subscriptions",
+      "type": "User",
+      "organizations_url": "https://api.github.com/users/naholyr/orgs",
+      "repos_url": "https://api.github.com/users/naholyr/repos",
+      "login": "naholyr",
+      "followers_url": "https://api.github.com/users/naholyr/followers"
+    },
+    "contributors_url": "https://api.github.com/repos/naholyr/gith/contributors",
+    "pulls_url": "https://api.github.com/repos/naholyr/gith/pulls{/number}"
+  },
+  "pull_request": {
+    "number": 4,
+    "issue_url": "https://github.com/naholyr/gith/issues/4",
+    "head": {
+      "label": "bonjourmodule:test3",
+      "repo": [
+        null
+      ],
+      "sha": "abd633ff2744039e4bda1c697cea3d03152df3fc",
+      "ref": "test3",
+      "user": [
+        null
+      ]
+    },
+    "merged_by": null,
+    "created_at": "2012-12-07T15:50:13Z",
+    "changed_files": 1,
+    "merged": false,
+    "comments": 0,
+    "body": "",
+    "title": "Test3",
+    "additions": 1,
+    "diff_url": "https://github.com/naholyr/gith/pull/4.diff",
+    "updated_at": "2012-12-07T15:50:13Z",
+    "url": "https://api.github.com/repos/naholyr/gith/pulls/4",
+    "_links": {
+      "html": [
+        null
+      ],
+      "self": [
+        null
+      ],
+      "comments": [
+        null
+      ],
+      "issue": [
+        null
+      ],
+      "review_comments": [
+        null
+      ]
+    },
+    "merge_commit_sha": "",
+    "review_comments_url": "https://github.com/naholyr/gith/pull/4/comments",
+    "id": 3281103,
+    "commits_url": "https://github.com/naholyr/gith/pull/4/commits",
+    "comments_url": "https://api.github.com/repos/naholyr/gith/issues/4/comments",
+    "assignee": null,
+    "patch_url": "https://github.com/naholyr/gith/pull/4.patch",
+    "mergeable_state": "unknown",
+    "mergeable": null,
+    "milestone": null,
+    "closed_at": null,
+    "merged_at": null,
+    "commits": 2,
+    "user": {
+      "avatar_url": "https://secure.gravatar.com/avatar/396445b6e14727dcb6b3d6a66d52b567?d=https://a248.e.akamai.net/assets.github.com%2Fimages%2Fgravatars%2Fgravatar-user-420.png",
+      "gists_url": "https://api.github.com/users/naholyr/gists{/gist_id}",
+      "received_events_url": "https://api.github.com/users/naholyr/received_events",
+      "events_url": "https://api.github.com/users/naholyr/events{/privacy}",
+      "gravatar_id": "396445b6e14727dcb6b3d6a66d52b567",
+      "url": "https://api.github.com/users/naholyr",
+      "starred_url": "https://api.github.com/users/naholyr/starred{/owner}{/repo}",
+      "id": 214067,
+      "following_url": "https://api.github.com/users/naholyr/following",
+      "subscriptions_url": "https://api.github.com/users/naholyr/subscriptions",
+      "type": "User",
+      "organizations_url": "https://api.github.com/users/naholyr/orgs",
+      "repos_url": "https://api.github.com/users/naholyr/repos",
+      "login": "naholyr",
+      "followers_url": "https://api.github.com/users/naholyr/followers"
+    },
+    "deletions": 135,
+    "review_comments": 0,
+    "html_url": "https://github.com/naholyr/gith/pull/4",
+    "state": "open",
+    "base": {
+      "label": "naholyr:master",
+      "repo": [
+        null
+      ],
+      "sha": "b493393b12a780735832a8ece5e16e723aef1318",
+      "ref": "master",
+      "user": [
+        null
+      ]
+    },
+    "review_comment_url": "/repos/naholyr/gith/pulls/comments/{number}"
+  },
+  "sender": {
+    "avatar_url": "https://secure.gravatar.com/avatar/396445b6e14727dcb6b3d6a66d52b567?d=https://a248.e.akamai.net/assets.github.com%2Fimages%2Fgravatars%2Fgravatar-user-420.png",
+    "events_url": "https://api.github.com/users/naholyr/events{/privacy}",
+    "gists_url": "https://api.github.com/users/naholyr/gists{/gist_id}",
+    "gravatar_id": "396445b6e14727dcb6b3d6a66d52b567",
+    "received_events_url": "https://api.github.com/users/naholyr/received_events",
+    "starred_url": "https://api.github.com/users/naholyr/starred{/owner}{/repo}",
+    "url": "https://api.github.com/users/naholyr",
+    "id": 214067,
+    "following_url": "https://api.github.com/users/naholyr/following",
+    "subscriptions_url": "https://api.github.com/users/naholyr/subscriptions",
+    "type": "User",
+    "organizations_url": "https://api.github.com/users/naholyr/orgs",
+    "repos_url": "https://api.github.com/users/naholyr/repos",
+    "login": "naholyr",
+    "followers_url": "https://api.github.com/users/naholyr/followers"
+  },
+  "action": "opened"
+}


### PR DESCRIPTION
I wanted to use this library as a `pull_request` web hook.

When a PR is received, the server crashes with:

```
/home/naholyr/gith-test/node_modules/gith/lib/gith.js:191
    pusher: payload.pusher.name,
                          ^
TypeError: Cannot read property 'name' of undefined
    at Gith.simplifyPayload (/home/naholyr/gith-test/node_modules/gith/lib/gith.js:191:27)
    at EventEmitter.Gith (/home/naholyr/gith-test/node_modules/gith/lib/gith.js:108:24)
    at EventEmitter.emit (/home/naholyr/gith-test/node_modules/gith/node_modules/eventemitter2/lib/eventemitter2.js:310:21)
[…]
```

I guess the payload is not always the same, depending on hook type.

I'll provide a fix in the week-end :)

Note: To achieve this goal you have to deploy the hook using API, because the web UI only declares `push` hooks.
