### PR TITLE
Typo: delimter -> delimiter

### DIFF
--- a/lib/gith.js
+++ b/lib/gith.js
@@ -267,7 +267,7 @@ module.exports.create = function( port ) {
 
   // make an event emitter to use for the hardcore stuff
   var eventaur = new EventEmitter2({
-    delimter: ':',
+    delimiter: ':',
     maxListeners: 0
   });
 


### PR DESCRIPTION
On line 100, delimiter was misspelled.
