### PR TITLE
Remove "payload=" prefix filtering on responses

### DIFF
--- a/lib/gith.js
+++ b/lib/gith.js
@@ -243,14 +243,13 @@ var listen = function( eventaur, port ) {
     req.on( "end", function() {
       if ( _.indexOf( gith.ips, req.connection.remoteAddress ) >= 0 ||
            _.indexOf( gith.ips, "*" ) >= 0 ) {
-        if ( /^payload=/.test( data ) ) {
-          var payload = JSON.parse( querystring.unescape(data.slice(8)) );
-          eventaur.emit( "payload", payload );
-          res.writeHead( 200, {
-            'Content-type': 'text/html'
-          });
-        }
-      }      
+
+        var payload = JSON.parse( querystring.unescape(data) );
+        eventaur.emit( "payload", payload );
+        res.writeHead( 200, {
+          'Content-type': 'text/html'
+        });
+      }
       res.end();
     });
 
@@ -281,11 +280,11 @@ module.exports.create = function( port ) {
   };
 
   // https://github.com/danheberden/gith/issues/13
-  ret.ips = [ 
-    '207.97.227.253', 
-    '50.57.128.197', 
-    '108.171.174.178', 
-    '50.57.231.61' 
+  ret.ips = [
+    '207.97.227.253',
+    '50.57.128.197',
+    '108.171.174.178',
+    '50.57.231.61'
   ];
 
   // add the listen method to the function - bind to ret

--- a/test/gith_test.js
+++ b/test/gith_test.js
@@ -123,7 +123,7 @@ exports['gith server'] = {
       host: 'localhost',
       method: 'POST'
     });
-    request.write( 'payload=' + JSON.stringify( payloadObject ) );
+    request.write( JSON.stringify( payloadObject ) );
     request.end();
   },
   'gith creates a server and listens to escaped payloads on that port': function( test ) {
@@ -154,7 +154,7 @@ exports['gith server'] = {
       host: 'localhost',
       method: 'POST'
     });
-    request.write( 'payload=' + querystring.escape( JSON.stringify( payloadObject ) ) );
+    request.write( querystring.escape( JSON.stringify( payloadObject ) ) );
     request.end();
   }
 };
@@ -398,7 +398,7 @@ exports['ip filtering'] = {
       host: 'localhost',
       method: 'POST'
     });
-    request.write( 'payload=' + querystring.escape( JSON.stringify( json ) ) );
+    request.write( querystring.escape( JSON.stringify( json ) ) );
     request.end();
 
     setTimeout( function() {
@@ -407,5 +407,3 @@ exports['ip filtering'] = {
     },300);
   }
 };
-
-


### PR DESCRIPTION
I'm not sure if the API changed or if this is related to something else like using an authorized API key (which I am not) but the post body I see from Github does not contain the prefix `payload=` which causes the whole program to essentially noop. If this needs to conditionally filter that prefix I'm happy to modify the PR.

This solves #20.

Thanks for the great module!
