### PR TITLE
Update packages to depend on stable lodash

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,8 +29,8 @@
     "test": "./node_modules/.bin/grunt test"
   },
   "dependencies": {
-    "eventemitter2" : ">= 0.4.9" ,
-    "lodash": ">= 0.3.2"
+    "eventemitter2" : ">= 0.4.14" ,
+    "lodash": ">= 1.0.0"
   },
   "devDependencies": {
     "grunt": "~0.3.14"


### PR DESCRIPTION
This bumps the lowest allowed lodash version to be the first stable release. Also I thought it might be good to make sure that eventemitter2 has the latest patches.
